### PR TITLE
Require activity like other resources

### DIFF
--- a/lib/amara.rb
+++ b/lib/amara.rb
@@ -17,6 +17,7 @@ require 'amara/videos'
 require 'amara/videos/languages'
 require 'amara/videos/languages/subtitles'
 require 'amara/videos/urls'
+require 'amara/activity'
 require 'amara/client'
 
 module Amara


### PR DESCRIPTION
The Activity class is not currently loaded like the others, adding a 'require' for it to the main amara.rb file.