### PR TITLE
Raise library-specific errors for easier handling by applications.

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,14 @@ new_team = amara.teams.create(
 
 ```
 
+In the event of an error from the Amara service, the error will be wrapped in one of the following exception clases.
+```ruby
+raise Amara::NotFoundError # 404 error
+raise Amara::ClientError # All other 400 errors
+raise Amara::ServerError # 500 errors
+raise Amara::UnknownError # All other errors
+```
+
 ## Contributing
 
 1. Fork it

--- a/lib/amara.rb
+++ b/lib/amara.rb
@@ -43,4 +43,9 @@ module Amara
     :admins   => 'Admins only'
   }
 
+  class Error         < ::StandardError; end
+  class ClientError   < Error; end
+  class NotFoundError < Error; end
+  class ServerError   < Error; end
+  class UnknownError  < Error; end
 end

--- a/lib/amara/response.rb
+++ b/lib/amara/response.rb
@@ -26,10 +26,16 @@ module Amara
       case status_code_type
       when "2"
         # puts "all is well, status: #{response.status}"
-      when "4", "5"
-        raise "Whoops, error back from Amara: #{response.status}"
+      when "4"
+        if response.status == 404
+          raise NotFoundError
+        else
+          raise ClientError, "Whoops, error back from Amara: #{response.status}"
+        end
+      when "5"
+        raise ServerError, "Whoops, error back from Amara: #{response.status}"
       else
-        raise "Unrecongized status code: #{response.status}"
+        raise UnknownError, "Unrecongized status code: #{response.status}"
       end
     end
 
@@ -111,4 +117,10 @@ module Amara
     end
 
   end
+
+  class AmaraError    < ::StandardError; end
+  class ClientError   < AmaraError; end
+  class NotFoundError < AmaraError; end
+  class ServerError   < AmaraError; end
+  class UnknownError  < AmaraError; end
 end

--- a/lib/amara/response.rb
+++ b/lib/amara/response.rb
@@ -117,10 +117,4 @@ module Amara
     end
 
   end
-
-  class AmaraError    < ::StandardError; end
-  class ClientError   < AmaraError; end
-  class NotFoundError < AmaraError; end
-  class ServerError   < AmaraError; end
-  class UnknownError  < AmaraError; end
 end

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -19,7 +19,7 @@ describe Amara::Client do
     amara.languages.wont_be_nil
   end
 
-  it "throws throws no error on 200" do
+  it "throws no error on 200" do
     stub_request(:get, 'https://www.amara.org/api2/partners/api/?limit=2&offset=0').
        to_return(body: nil, status: 200)
     begin

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -19,4 +19,45 @@ describe Amara::Client do
     amara.languages.wont_be_nil
   end
 
+  it "throws throws no error on 200" do
+    stub_request(:get, 'https://www.amara.org/api2/partners/api/?limit=2&offset=0').
+       to_return(body: nil, status: 200)
+    begin
+      Amara::API.new.list(limit: 2)
+    rescue
+      flunk "Client error should not be thrown!"
+    end
+  end
+
+  it "throws a client error on 400s (except 404)" do
+    stub_request(:get, 'https://www.amara.org/api2/partners/api/?limit=2&offset=0').
+       to_return(body: nil, status: 400)
+    proc {
+      Amara::API.new.list(limit: 2)
+    }.must_raise Amara::ClientError
+  end
+
+  it "throws a not found error on 404" do
+    stub_request(:get, 'https://www.amara.org/api2/partners/api/?limit=2&offset=0').
+       to_return(body: nil, status: 404)
+    proc {
+      Amara::API.new.list(limit: 2)
+    }.must_raise Amara::NotFoundError
+  end
+
+  it "throws a server error on 500s" do
+    stub_request(:get, 'https://www.amara.org/api2/partners/api/?limit=2&offset=0').
+       to_return(body: nil, status: 500)
+    proc {
+      Amara::API.new.list(limit: 2)
+    }.must_raise Amara::ServerError
+  end
+
+  it "throws an unknown error on all other errors" do
+    stub_request(:get, 'https://www.amara.org/api2/partners/api/?limit=2&offset=0').
+       to_return(body: nil, status: 601)
+    proc {
+      Amara::API.new.list(limit: 2)
+    }.must_raise Amara::UnknownError
+  end
 end


### PR DESCRIPTION
I'm proposing instead of raising a bare RuntimeError, raise specific errors for this library. This allows applications to catch, for example, a 404 error from Amara and handle it specifically. What do you think?