### PR TITLE
Add ability to hit API for custom paths

### DIFF
--- a/lib/amara.rb
+++ b/lib/amara.rb
@@ -18,6 +18,7 @@ require 'amara/videos/languages'
 require 'amara/videos/languages/subtitles'
 require 'amara/videos/urls'
 require 'amara/activity'
+require 'amara/path'
 require 'amara/client'
 
 module Amara

--- a/lib/amara/client.rb
+++ b/lib/amara/client.rb
@@ -27,5 +27,10 @@ module Amara
       @users ||= ApiFactory.api('Amara::Users', self, params, &block)
     end
 
+    def path(path, params={}, &block)
+      @path ||= ApiFactory.api('Amara::Path', self, params, &block)
+      @path.current_options['path'] = path
+      @path
+    end
   end
 end

--- a/lib/amara/path.rb
+++ b/lib/amara/path.rb
@@ -1,0 +1,14 @@
+# -*- encoding: utf-8 -*-
+
+module Amara
+  class Path < API
+    def base_path
+      path = self.current_options[:path]
+      if path.kind_of? Array
+        path.join('/')
+      else
+        path
+      end
+    end
+  end
+end

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -19,4 +19,8 @@ describe Amara::Client do
     amara.languages.wont_be_nil
   end
 
+  it "returns a path api object" do
+    amara = Amara::Client.new
+    amara.path('some/path').wont_be_nil
+  end
 end

--- a/test/path_test.rb
+++ b/test/path_test.rb
@@ -1,0 +1,24 @@
+# -*- encoding: utf-8 -*-
+
+require File.expand_path(File.dirname(__FILE__) + '/test_helper')
+
+describe Amara::Path do
+
+  it "returns a path api object" do
+    amara = Amara::Client.new
+    assert_equal amara.path('some/path').class, Amara::Path
+  end
+
+  it "raises an exception if no path is passed" do
+    amara = Amara::Client.new
+    assert_raises ArgumentError do
+      amara.path.wont_be_nil
+    end
+  end
+
+  it "sets the custom path" do
+    amara = Amara::Client.new
+    path = amara.path('some/path')
+    assert_equal 'some/path', path.current_options['path']
+  end
+end


### PR DESCRIPTION
Our project needs to hit custom API paths for Amara. The Amara gem currently only allows access to predefined/documented paths. I added this AmaraClient#path option to give us, and anyone else, access to hit custom API paths. I suspect we aren't the only team who has custom API endpoints, so I hope this option will be useful to other teams as well.