### PR TITLE
if payload contains a 'url', don't use this to configure the client

### DIFF
--- a/lib/amara/api.rb
+++ b/lib/amara/api.rb
@@ -31,6 +31,14 @@ module Amara
       end
     end
 
+    def update_current_options!(options)
+      # any of these which are present in options get dropped
+      invalid_options = [:url]
+
+      new_options = args_to_options(options).except(*invalid_options)
+      self.current_options = current_options.merge(new_options)
+    end
+
     def request(method, path, params={}) # :nodoc:
       unless (method && [:get, :post, :put, :patch, :delete].include?(method))
         raise ArgumentError, "whoops, that isn't a valid http method: #{method}"
@@ -97,7 +105,7 @@ module Amara
     end
 
     def list(params={})
-      self.current_options = current_options.merge(args_to_options(params))
+      update_current_options!(params)
       request(:get, base_path, paginate(params))
     end
 
@@ -106,7 +114,7 @@ module Amara
     end
 
     def get(params={})
-      self.current_options = current_options.merge(args_to_options(params))
+      update_current_options!(params)
       request(:get, base_path)
     end
 
@@ -115,7 +123,7 @@ module Amara
     end
 
     def create(params={})
-      self.current_options = current_options.merge(args_to_options(params))
+      update_current_options!(params)
       request(:post, base_path, {data: params})
     end
 
@@ -124,7 +132,7 @@ module Amara
     end
 
     def update(params={})
-      self.current_options = current_options.merge(args_to_options(params))
+      update_current_options!(params)
       request(:put, base_path, {data: params})
     end
 
@@ -133,7 +141,7 @@ module Amara
     end
 
     def delete(params={})
-      self.current_options = current_options.merge(args_to_options(params))
+      update_current_options!(params)
       request(:delete, base_path)
     end
 

--- a/test/api_test.rb
+++ b/test/api_test.rb
@@ -127,4 +127,16 @@ describe Amara::API do
 
     assert_requested stub_post
   end
+
+  it "should allow a 'url' parameter" do
+    expected_body = { url: 'http://example.com' }
+
+    stub_post = stub_request(:post, 'https://www.amara.org/api2/partners/api/').
+      with(body: expected_body.to_json)
+
+    api = Amara::API.new
+    api.create!(expected_body)
+
+    assert_requested stub_post
+  end
 end


### PR DESCRIPTION
refs prx/amara#12

this is an attempt at the simpler of the two options i hypothesized in [this comment](https://github.com/PRX/amara/issues/12#issuecomment-280406011).

@kookster are there legitimate reasons why `:url` should sometimes be interpreted as a configuration option rather than a parameter to be sent to the server? that would invalidate this approach, but i can't think of any.

the purpose of saving client state in `self.current_options` is unclear to me. i suspect it's related to automatically doing pagination, but i'm not sure.